### PR TITLE
add REST API controller for render pr deployments authentication

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { AuthController } from './auth.controller'
+
+describe('AuthController', () => {
+  let controller: AuthController
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+    }).compile()
+
+    controller = module.get<AuthController>(AuthController)
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+})

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Query, Res } from '@nestjs/common'
+import { Response } from 'express'
+import { ParseKeyValuePipe } from 'src/common/pipes/keyvalue.pipe'
+
+@Controller('auth')
+export class AuthController {
+  @Get('/callback')
+  callback(
+    @Query('code') code: string,
+    @Query('state', ParseKeyValuePipe) state: Record<string, string>,
+    @Res() res: Response
+  ): void {
+    const returnURI = state['returnURI']
+    res.redirect(`${returnURI}?code=${code}`)
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { UserSchema } from 'src/schemas/user.schema'
 import { JwtModule } from '@nestjs/jwt'
 import { ConfigService } from '@nestjs/config'
 import { JwtStrategy } from './jwt.strategy'
+import { AuthController } from './auth.controller'
 
 @Module({
   imports: [
@@ -19,5 +20,6 @@ import { JwtStrategy } from './jwt.strategy'
     HttpModule,
   ],
   providers: [AuthResolver, AuthService, JwtStrategy],
+  controllers: [AuthController],
 })
 export class AuthModule {}

--- a/src/common/pipes/keyvalue.pipe.ts
+++ b/src/common/pipes/keyvalue.pipe.ts
@@ -1,0 +1,30 @@
+import {
+  PipeTransform,
+  Injectable,
+  ArgumentMetadata,
+  BadRequestException,
+} from '@nestjs/common'
+
+@Injectable()
+export class ParseKeyValuePipe
+  implements PipeTransform<string, Record<string, string>> {
+  transform(value: string, metadata: ArgumentMetadata): Record<string, string> {
+    const pairs = value.split('&').map((pair) => pair.split('='))
+
+    // there exists a pair that doesn't follow 'key=value' format
+    if (pairs.some((pair) => pair.length != 2)) {
+      throw new BadRequestException({
+        reason: 'KEY_VALUE_PAIR_INVALID',
+        message: "Some key value pairs does not contain '-'",
+        value: value,
+      })
+    }
+
+    const pairsRecord: Record<string, string> = {}
+    pairs.forEach((pair) => {
+      pairsRecord[pair[0]] = pair[1]
+    })
+
+    return pairsRecord
+  }
+}


### PR DESCRIPTION
For Render PR Deployments, normal authentication flow is impossible (as the domain will change every pr, and every redirect uri must be manually authorized in the Google Cloud Console).

To solve this, we need to use our backend as the redirect uri. After user confirms their consent, Google will redirect to `/auth/callback` with query parameter `code` and `state`. This endpoint will extract the authorization code and the PR's deployment uri (returnURI) in the state and redirect to the deployment with the code in the query parameter. The deployment can then extract the code and send to backend for verification per normal authentication flow. The deployment can then  For more information about Google OAuth's state parameter, see ([docs](https://developers.google.com/identity/protocols/oauth2/web-server#creatingclient)).

Official CU Get Reg documentation regarding GraphQL and Authentication Flow is coming soon.