### PR TITLE
don't restart mongo if manually stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   mongo:
     container_name: cgr-mongo
     image: mongo
-    restart: always
+    restart: unless-stopped
     volumes:
       - ./volumes/mongo:/data/db
     ports:


### PR DESCRIPTION
`restart: always` always restart container on startup, which can be annoying when you have multiple projects with this. `restart: unless-stopped` lets you choose which container you want to start on startup.