### PR TITLE
make graphql exceptions more accessible

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { UserModule } from './user/user.module'
 import { AuthModule } from './auth/auth.module'
 import configuration from './config/configuration'
 import { GraphQLExpressContext } from './common/types/context.type'
+import { GraphQLError } from 'graphql'
 
 @Module({
   imports: [
@@ -25,6 +26,17 @@ import { GraphQLExpressContext } from './common/types/context.type'
         outputAs: 'class',
       },
       context: ({ req, res }: GraphQLExpressContext) => ({ req, res }),
+      formatError: (error: GraphQLError) => {
+        const graphQLFormattedError = {
+          message:
+            error?.extensions?.exception?.response?.message || error.message,
+          path: error.path,
+          locations: error.locations,
+          reason: error?.extensions?.exception?.response?.reason,
+          status: error?.extensions?.exception?.status,
+        }
+        return graphQLFormattedError
+      },
     }),
     CourseModule,
     CommonModule,


### PR DESCRIPTION
moved error reason and status to the first level

however, graphql still returns 200 OK even if error is thrown (the error will be in the `errors` field instead)

![image](https://user-images.githubusercontent.com/24814968/107656937-3a6d7900-6cb7-11eb-9ca4-676362ba09c5.png)
