### PR TITLE
fix: fix period range query on array of classes

### DIFF
--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -159,8 +159,12 @@ export class CourseService implements OnApplicationBootstrap {
           message: 'Start time cannot be later than end time',
         })
       }
-      query['sections.classes.period.start'] = { $lt: end }
-      query['sections.classes.period.end'] = { $gt: start }
+      query['sections.classes'] = {
+        $elemMatch: {
+          'period.start': { $lt: end },
+          'period.end': { $gt: start },
+        },
+      }
     }
 
     const courses = await this.courseModel


### PR DESCRIPTION
Before, the period range query would return courses if a combination of classes would satisfy the `sections.classes.period.start` and `sections.classes.period.end` conditions separately. Obviously, that's not what we want. I fixed it so it would only return course IF there is a class that satisfy BOTH conditions.