### PR TITLE
fix: fix period range query on array of classes

### DIFF
--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -161,8 +161,8 @@ export class CourseService implements OnApplicationBootstrap {
       }
       query['sections.classes'] = {
         $elemMatch: {
-          'period.start': { $lt: end },
-          'period.end': { $gt: start },
+          'period.start': { $gte: start },
+          'period.end': { $lte: end },
         },
       }
     }


### PR DESCRIPTION
Before, the periodRange filter would return the course if the course has any class partially intersecting with the period range. Now, it will only return the course if the course has any class FULLY INTERSECTING with the range.

To test:
1. go to https://dev.cugetreg.com/api/graphql
2. Execute the following query
```gql
query search($filter: FilterInput!, $courseGroup: CourseGroupInput!) {
  search(filter: $filter, courseGroup: $courseGroup) {
    courseNo
    abbrName
    courseDesc
    sections {
      classes {
        dayOfWeek
        period {
          start
          end
        }
      }
    }
  }
}
```
with variables:
```json
{
  "filter": {
    "limit": 10,
    "periodRange": {
      "start": "08:00",
      "end": "09:30"
    }
  },
  "courseGroup": {
    "semester": "2",
    "academicYear": "2564",
    "studyProgram": "S"
  }
}
```