### PR TITLE
allow custom return url

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,6 @@
 MONGO_URI=mongodb://localhost:27017/cugetreg
 PORT=3000
+ENV=development
 
 GOOGLE_OAUTH_ID="<insert_client_id>"
 GOOGLE_OAUTH_SECRET=<insert_client_secret>

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -12,6 +12,7 @@ export default () => ({
   adminToken: process.env.ADMIN_TOKEN,
   clientLoggerUrl: process.env.CLIENT_LOGGER_URL,
   computationBackendUrl: process.env.COMPUTATION_BACKEND_URL,
+  env: process.env.ENV || 'development',
 })
 
 const requiredConfigs = [


### PR DESCRIPTION
allow custom return url after google auth to allow persisting url after login

for security reasons, cross-origin return urls are only allowed in dev environment (for local frontend). Beta and prod return urls must begin with backendPublicUrl

cc @paphonb