### PR TITLE
fix: set isHidden for new courseCart item

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -149,6 +149,7 @@ export class AuthService {
             item.semester = e.semester
             item.studyProgram = e.studyProgram
             item.selectedSectionNo = e.selectedSectionNo
+            item.isHidden = false
             await validateOrReject(item, { forbidUnknownValues: true })
             courseCart.cartContent.push(item)
           }


### PR DESCRIPTION
`Error while migrating GDrive data` spiked after isHidden is added because i forgot to set it when migrating gdrive data