### PR TITLE
fix: move populate override to scraper

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@nestjs/passport": "^7.1.5",
     "@nestjs/platform-express": "^7.5.1",
     "@nestjs/schedule": "^0.4.3",
-    "@thinc-org/chula-courses": "^2.2.0",
+    "@thinc-org/chula-courses": "^2.3.0",
     "@typegoose/typegoose": "^9.1.0",
     "@types/cookie-parser": "^1.4.2",
     "apollo-server-express": "^2.19.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@nestjs/passport": "^7.1.5",
     "@nestjs/platform-express": "^7.5.1",
     "@nestjs/schedule": "^0.4.3",
-    "@thinc-org/chula-courses": "^1.1.12",
+    "@thinc-org/chula-courses": "^2.2.0",
     "@typegoose/typegoose": "^9.1.0",
     "@types/cookie-parser": "^1.4.2",
     "apollo-server-express": "^2.19.2",

--- a/src/course/course.graphql
+++ b/src/course/course.graphql
@@ -97,7 +97,3 @@ type Query {
   course(courseNo: String!, courseGroup: CourseGroupInput!): Course!
   search(filter: FilterInput!, courseGroup: CourseGroupInput!): [Course!]!
 }
-
-type Mutation {
-  refresh: String!
-}

--- a/src/course/course.graphql
+++ b/src/course/course.graphql
@@ -39,7 +39,8 @@ type Course {
 
   # Course info
   courseNo: String!
-  courseDesc: String
+  courseDescTh: String
+  courseDescEn: String
   abbrName: String!
   courseNameTh: String!
   courseNameEn: String!
@@ -59,6 +60,10 @@ type Course {
 
   # Rating
   rating: String
+
+  # Deprecated
+  courseDesc: String
+    @deprecated(reason: "Use courseDescTh or courseDescEn instead")
 }
 
 input PeriodRangeInput {

--- a/src/course/course.module.ts
+++ b/src/course/course.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import { OverrideModule } from 'src/override/override.module'
 import { ReviewModule } from 'src/review/review.module'
 import { CourseSchema } from 'src/schemas/course.schema'
 import { CourseResolver } from './course.resolver'
@@ -9,7 +8,6 @@ import { CourseService } from './course.service'
 @Module({
   imports: [
     ReviewModule,
-    OverrideModule,
     MongooseModule.forFeature([{ name: 'course', schema: CourseSchema }]),
   ],
   providers: [CourseResolver, CourseService],

--- a/src/course/course.module.ts
+++ b/src/course/course.module.ts
@@ -1,13 +1,11 @@
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import { ReviewModule } from 'src/review/review.module'
 import { CourseSchema } from 'src/schemas/course.schema'
 import { CourseResolver } from './course.resolver'
 import { CourseService } from './course.service'
 
 @Module({
   imports: [
-    ReviewModule,
     MongooseModule.forFeature([{ name: 'course', schema: CourseSchema }]),
   ],
   providers: [CourseResolver, CourseService],

--- a/src/course/course.resolver.ts
+++ b/src/course/course.resolver.ts
@@ -1,7 +1,5 @@
-import { UseGuards } from '@nestjs/common'
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
+import { Args, Query, Resolver } from '@nestjs/graphql'
 import { Course, Semester, StudyProgram } from '@thinc-org/chula-courses'
-import { AdminAuthGuard } from 'src/auth/admin.guard'
 import { CourseGroupInput, FilterInput } from 'src/graphql'
 import { CourseService } from './course.service'
 
@@ -34,12 +32,5 @@ export class CourseResolver {
     @Args('courseGroup') courseGroup: CourseGroupInput
   ): Promise<Course[]> {
     return this.courseService.search(filter, courseGroup)
-  }
-
-  @UseGuards(AdminAuthGuard)
-  @Mutation('refresh')
-  async refresh(): Promise<string> {
-    this.courseService.refresh()
-    return 'Refreshed course overrides and ratings.'
   }
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -211,9 +211,18 @@ export class CourseNosOutput {
     I: string[];
 }
 
-export abstract class IMutation {
-    abstract refresh(): string | Promise<string>;
+export class GenEdOverride {
+    genEdType: GenEdType;
+    sections: string[];
+}
 
+export class Override {
+    courseNo: string;
+    studyProgram: StudyProgram;
+    genEd?: GenEdOverride;
+}
+
+export abstract class IMutation {
     abstract createOrUpdateOverride(override: OverrideInput): Override | Promise<Override>;
 
     abstract deleteOverride(courseNo: string, studyProgram: StudyProgram): Override | Promise<Override>;
@@ -231,17 +240,6 @@ export abstract class IMutation {
     abstract modifyCourseCart(newContent: CourseCartItemInput[]): CourseCartItem[] | Promise<CourseCartItem[]>;
 
     abstract modifyCalendarId(newCalendarId?: string): string | Promise<string>;
-}
-
-export class GenEdOverride {
-    genEdType: GenEdType;
-    sections: string[];
-}
-
-export class Override {
-    courseNo: string;
-    studyProgram: StudyProgram;
-    genEd?: GenEdOverride;
 }
 
 export class Review {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -93,7 +93,6 @@ export class GenEdOverrideInput {
 export class OverrideInput {
     courseNo: string;
     studyProgram: StudyProgram;
-    courseDesc?: string;
     genEd?: GenEdOverrideInput;
 }
 
@@ -188,7 +187,8 @@ export class Course {
     semester: string;
     academicYear: string;
     courseNo: string;
-    courseDesc?: string;
+    courseDescTh?: string;
+    courseDescEn?: string;
     abbrName: string;
     courseNameTh: string;
     courseNameEn: string;
@@ -202,6 +202,7 @@ export class Course {
     final?: ExamPeriod;
     sections: Section[];
     rating?: string;
+    courseDesc?: string;
 }
 
 export class CourseNosOutput {
@@ -240,7 +241,6 @@ export class GenEdOverride {
 export class Override {
     courseNo: string;
     studyProgram: StudyProgram;
-    courseDesc?: string;
     genEd?: GenEdOverride;
 }
 

--- a/src/override/override.graphql
+++ b/src/override/override.graphql
@@ -6,7 +6,6 @@ type GenEdOverride {
 type Override {
   courseNo: String!
   studyProgram: StudyProgram!
-  courseDesc: String
   genEd: GenEdOverride
 }
 
@@ -18,7 +17,6 @@ input GenEdOverrideInput {
 input OverrideInput {
   courseNo: String!
   studyProgram: StudyProgram!
-  courseDesc: String
   genEd: GenEdOverrideInput
 }
 

--- a/src/review/review.resolver.ts
+++ b/src/review/review.resolver.ts
@@ -5,7 +5,7 @@ import { AdminAuthGuard } from 'src/auth/admin.guard'
 import { JwtAuthGuard, JwtAuthGuardOptional } from 'src/auth/jwt.guard'
 import { CurrentUser } from 'src/common/decorators/currentUser.decorator'
 import { CreateReviewInput, EditReviewInput, Review, Status } from 'src/graphql'
-import { Interaction } from 'src/schemas/review.schema'
+import { InteractionType } from 'src/schemas/review.schema'
 import { ReviewService } from './review.service'
 
 @Resolver('Review')
@@ -44,7 +44,7 @@ export class ReviewResolver {
   @Mutation('setInteraction')
   async like(
     @Args('reviewId') reviewId: string,
-    @Args('interaction') interaction: Interaction,
+    @Args('interaction') interaction: InteractionType,
     @CurrentUser() userId: string
   ): Promise<Review> {
     return this.reviewService.setInteraction(reviewId, interaction, userId)

--- a/src/review/review.resolver.ts
+++ b/src/review/review.resolver.ts
@@ -5,7 +5,7 @@ import { AdminAuthGuard } from 'src/auth/admin.guard'
 import { JwtAuthGuard, JwtAuthGuardOptional } from 'src/auth/jwt.guard'
 import { CurrentUser } from 'src/common/decorators/currentUser.decorator'
 import { CreateReviewInput, EditReviewInput, Review, Status } from 'src/graphql'
-import { InteractionType } from 'src/schemas/review.schema'
+import { ReviewInteractionType } from 'src/schemas/review.schema'
 import { ReviewService } from './review.service'
 
 @Resolver('Review')
@@ -44,7 +44,7 @@ export class ReviewResolver {
   @Mutation('setInteraction')
   async like(
     @Args('reviewId') reviewId: string,
-    @Args('interaction') interaction: InteractionType,
+    @Args('interaction') interaction: ReviewInteractionType,
     @CurrentUser() userId: string
   ): Promise<Review> {
     return this.reviewService.setInteraction(reviewId, interaction, userId)

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -15,7 +15,7 @@ import {
   Status,
   StudyProgram as GraphQLStudyProgram,
 } from 'src/graphql'
-import { Interaction, ReviewDocument } from 'src/schemas/review.schema'
+import { InteractionType, ReviewDocument } from 'src/schemas/review.schema'
 
 @Injectable()
 export class ReviewService {
@@ -186,7 +186,7 @@ export class ReviewService {
 
   async setInteraction(
     reviewId: string,
-    interaction: Interaction,
+    interaction: InteractionType,
     userId: string
   ): Promise<Review> {
     const review = await this.reviewModel.findById(reviewId)

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -15,7 +15,10 @@ import {
   Status,
   StudyProgram as GraphQLStudyProgram,
 } from 'src/graphql'
-import { InteractionType, ReviewDocument } from 'src/schemas/review.schema'
+import {
+  ReviewDocument,
+  ReviewInteractionType,
+} from 'src/schemas/review.schema'
 
 @Injectable()
 export class ReviewService {
@@ -186,7 +189,7 @@ export class ReviewService {
 
   async setInteraction(
     reviewId: string,
-    interaction: InteractionType,
+    interaction: ReviewInteractionType,
     userId: string
   ): Promise<Review> {
     const review = await this.reviewModel.findById(reviewId)

--- a/src/schemas/course.schema.ts
+++ b/src/schemas/course.schema.ts
@@ -84,6 +84,7 @@ export const CourseSchema = new mongoose.Schema({
   midterm: examPeriod,
   final: examPeriod,
   sections: { type: [section], required: true },
+  rating: { type: String },
 })
 
 export type CourseDocument = Course & mongoose.Document

--- a/src/schemas/override.schema.ts
+++ b/src/schemas/override.schema.ts
@@ -13,14 +13,12 @@ export const GenEdSchema = new mongoose.Schema({
 export const OverrideSchema = new mongoose.Schema({
   courseNo: { type: String, required: true },
   studyProgram: { type: String, required: true, enum: ['S', 'T', 'I'] },
-  courseDesc: { type: String },
   genEd: { type: GenEdSchema },
 })
 
 export interface Override {
   courseNo: string
   studyProgram: StudyProgram
-  courseDesc?: string
   genEd?: {
     genEdType: GenEdType
     sections: string[]

--- a/src/schemas/review.schema.ts
+++ b/src/schemas/review.schema.ts
@@ -22,15 +22,17 @@ export const ReviewSchema = new mongoose.Schema({
   status: { type: String, default: 'PENDING' },
 })
 
-export type Interaction = 'L' | 'D'
+export type InteractionType = 'L' | 'D'
 export type ReviewStatus = 'PENDING' | 'APPROVED' | 'HIDDEN'
 
-export interface InteractionDocument extends mongoose.Document {
+export interface Interaction {
   userId: mongoose.Types.ObjectId
-  type: Interaction
+  type: InteractionType
 }
 
-export interface ReviewDocument extends mongoose.Document {
+export type InteractionDocument = Interaction & mongoose.Document
+
+export interface Review {
   ownerId: mongoose.Types.ObjectId
   rating: number
   courseNo: string
@@ -41,3 +43,5 @@ export interface ReviewDocument extends mongoose.Document {
   interactions: mongoose.Types.DocumentArray<InteractionDocument>
   status: ReviewStatus
 }
+
+export type ReviewDocument = Review & mongoose.Document

--- a/src/schemas/review.schema.ts
+++ b/src/schemas/review.schema.ts
@@ -22,15 +22,15 @@ export const ReviewSchema = new mongoose.Schema({
   status: { type: String, default: 'PENDING' },
 })
 
-export type InteractionType = 'L' | 'D'
+export type ReviewInteractionType = 'L' | 'D'
 export type ReviewStatus = 'PENDING' | 'APPROVED' | 'HIDDEN'
 
-export interface Interaction {
+export interface ReviewInteraction {
   userId: mongoose.Types.ObjectId
-  type: InteractionType
+  type: ReviewInteractionType
 }
 
-export type InteractionDocument = Interaction & mongoose.Document
+export type ReviewInteractionDocument = ReviewInteraction & mongoose.Document
 
 export interface Review {
   ownerId: mongoose.Types.ObjectId
@@ -40,7 +40,7 @@ export interface Review {
   academicYear: string
   studyProgram: StudyProgram
   content?: string
-  interactions: mongoose.Types.DocumentArray<InteractionDocument>
+  interactions: mongoose.Types.DocumentArray<ReviewInteractionDocument>
   status: ReviewStatus
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,10 +1393,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@thinc-org/chula-courses@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@thinc-org/chula-courses/-/chula-courses-2.2.0.tgz#a47c859b6e81d95d85ac7c59d4cfd5a2b159e74a"
-  integrity sha512-jQiFx6MoRWnBMEgZ1U1ZUZM/iLE9PfNfGreectzCzWMfh52hPxuIOV/Ae/MZzLPFLcWqmw5zr7/a/co+Ik3Qvw==
+"@thinc-org/chula-courses@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@thinc-org/chula-courses/-/chula-courses-2.3.0.tgz#28518dee973d31a6e17c9162c33ccb7924434be1"
+  integrity sha512-ooi0sK83sLDMhhDSwDDwyy0EsvX7hZduU6jwG0v+n74t+DbJiFZnncR/6bsZoT4N/9u35FKKPGMHFNyUHSYVyA==
   dependencies:
     axios "^0.21.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,10 +1393,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@thinc-org/chula-courses@^1.1.12":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@thinc-org/chula-courses/-/chula-courses-1.2.1.tgz#2bce461e7b76b5d86386e84e3a5574e531f22135"
-  integrity sha512-SNtw0tjZcWlB4Yer1R7lE8WGXKK+ncrucEp1Y2bBj4MrRZwetCwXkN/KsEcXw8T5BShZtgDIxx5WmeF1+RYFsg==
+"@thinc-org/chula-courses@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@thinc-org/chula-courses/-/chula-courses-2.2.0.tgz#a47c859b6e81d95d85ac7c59d4cfd5a2b159e74a"
+  integrity sha512-jQiFx6MoRWnBMEgZ1U1ZUZM/iLE9PfNfGreectzCzWMfh52hPxuIOV/Ae/MZzLPFLcWqmw5zr7/a/co+Ik3Qvw==
   dependencies:
     axios "^0.21.1"
 


### PR DESCRIPTION
- move populate course override stuff and rating stuff to scraper instead (except override CRUD API)
- no more caching, so refreshing cache is no longer needed
- add `courseDescTh` and `courseDescEn` to graphql schema and deprecate `courseDesc`
- refactor review schema

## Frontend changes
- use `courseDescTh` and `courseDescEn` instead of `courseDesc`

## Note
- might move types and schemas to `chula-courses` soon