### PR TITLE
Fix review query behaviour

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -55,7 +55,7 @@ export enum Interaction {
     D = "D"
 }
 
-export enum Status {
+export enum ReviewStatus {
     APPROVED = "APPROVED",
     REJECTED = "REJECTED"
 }
@@ -235,7 +235,7 @@ export abstract class IMutation {
 
     abstract setInteraction(reviewId: string, interaction: Interaction): Review | Promise<Review>;
 
-    abstract setReviewStatus(reviewId: string, status: Status): string | Promise<string>;
+    abstract setReviewStatus(reviewId: string, status: ReviewStatus): string | Promise<string>;
 
     abstract modifyCourseCart(newContent: CourseCartItemInput[]): CourseCartItem[] | Promise<CourseCartItem[]>;
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -254,6 +254,7 @@ export class Review {
     likeCount: number;
     dislikeCount: number;
     myInteraction?: ReviewInteractionType;
+    status?: ReviewStatus;
 }
 
 export class GoogleCredential {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -234,7 +234,7 @@ export abstract class IMutation {
 
     abstract editMyReview(reviewId: string, review: EditReviewInput): Review | Promise<Review>;
 
-    abstract setInteraction(reviewId: string, interaction: ReviewInteractionType): Review | Promise<Review>;
+    abstract setReviewInteraction(reviewId: string, interactionType: ReviewInteractionType): Review | Promise<Review>;
 
     abstract setReviewStatus(reviewId: string, status: ReviewStatus): string | Promise<string>;
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -50,14 +50,15 @@ export enum GenEdType {
     NO = "NO"
 }
 
-export enum Interaction {
+export enum ReviewInteractionType {
     L = "L",
     D = "D"
 }
 
 export enum ReviewStatus {
     APPROVED = "APPROVED",
-    REJECTED = "REJECTED"
+    REJECTED = "REJECTED",
+    PENDING = "PENDING"
 }
 
 export class CourseEntryInput {
@@ -233,7 +234,7 @@ export abstract class IMutation {
 
     abstract editMyPendingReview(reviewId: string, review: EditReviewInput): Review | Promise<Review>;
 
-    abstract setInteraction(reviewId: string, interaction: Interaction): Review | Promise<Review>;
+    abstract setInteraction(reviewId: string, interaction: ReviewInteractionType): Review | Promise<Review>;
 
     abstract setReviewStatus(reviewId: string, status: ReviewStatus): string | Promise<string>;
 
@@ -252,7 +253,7 @@ export class Review {
     content?: string;
     likeCount: number;
     dislikeCount: number;
-    myInteraction?: Interaction;
+    myInteraction?: ReviewInteractionType;
 }
 
 export class GoogleCredential {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -232,7 +232,7 @@ export abstract class IMutation {
 
     abstract removeReview(reviewId: string): Review | Promise<Review>;
 
-    abstract editMyPendingReview(reviewId: string, review: EditReviewInput): Review | Promise<Review>;
+    abstract editMyReview(reviewId: string, review: EditReviewInput): Review | Promise<Review>;
 
     abstract setInteraction(reviewId: string, interaction: ReviewInteractionType): Review | Promise<Review>;
 
@@ -255,6 +255,7 @@ export class Review {
     dislikeCount: number;
     myInteraction?: ReviewInteractionType;
     status?: ReviewStatus;
+    isOwner: boolean;
 }
 
 export class GoogleCredential {

--- a/src/review/review.graphql
+++ b/src/review/review.graphql
@@ -3,7 +3,7 @@ enum Interaction {
   D
 }
 
-enum Status {
+enum ReviewStatus {
   APPROVED
   REJECTED
 }
@@ -48,5 +48,5 @@ type Mutation {
   removeReview(reviewId: String!): Review!
   editMyPendingReview(reviewId: String!, review: EditReviewInput!): Review!
   setInteraction(reviewId: String!, interaction: Interaction!): Review!
-  setReviewStatus(reviewId: String!, status: Status!): String!
+  setReviewStatus(reviewId: String!, status: ReviewStatus!): String!
 }

--- a/src/review/review.graphql
+++ b/src/review/review.graphql
@@ -50,9 +50,9 @@ type Mutation {
   createReview(createReviewInput: CreateReviewInput!): Review!
   removeReview(reviewId: String!): Review!
   editMyReview(reviewId: String!, review: EditReviewInput!): Review!
-  setInteraction(
+  setReviewInteraction(
     reviewId: String!
-    interaction: ReviewInteractionType!
+    interactionType: ReviewInteractionType!
   ): Review!
   setReviewStatus(reviewId: String!, status: ReviewStatus!): String!
 }

--- a/src/review/review.graphql
+++ b/src/review/review.graphql
@@ -20,6 +20,7 @@ type Review {
   likeCount: Int!
   dislikeCount: Int!
   myInteraction: ReviewInteractionType
+  status: ReviewStatus
 }
 
 input CreateReviewInput {

--- a/src/review/review.graphql
+++ b/src/review/review.graphql
@@ -1,4 +1,4 @@
-enum Interaction {
+enum ReviewInteractionType {
   L
   D
 }
@@ -6,6 +6,7 @@ enum Interaction {
 enum ReviewStatus {
   APPROVED
   REJECTED
+  PENDING
 }
 
 type Review {
@@ -18,7 +19,7 @@ type Review {
   content: String
   likeCount: Int!
   dislikeCount: Int!
-  myInteraction: Interaction
+  myInteraction: ReviewInteractionType
 }
 
 input CreateReviewInput {
@@ -47,6 +48,9 @@ type Mutation {
   createReview(createReviewInput: CreateReviewInput!): Review!
   removeReview(reviewId: String!): Review!
   editMyPendingReview(reviewId: String!, review: EditReviewInput!): Review!
-  setInteraction(reviewId: String!, interaction: Interaction!): Review!
+  setInteraction(
+    reviewId: String!
+    interaction: ReviewInteractionType!
+  ): Review!
   setReviewStatus(reviewId: String!, status: ReviewStatus!): String!
 }

--- a/src/review/review.graphql
+++ b/src/review/review.graphql
@@ -21,6 +21,7 @@ type Review {
   dislikeCount: Int!
   myInteraction: ReviewInteractionType
   status: ReviewStatus
+  isOwner: Boolean!
 }
 
 input CreateReviewInput {
@@ -48,7 +49,7 @@ type Query {
 type Mutation {
   createReview(createReviewInput: CreateReviewInput!): Review!
   removeReview(reviewId: String!): Review!
-  editMyPendingReview(reviewId: String!, review: EditReviewInput!): Review!
+  editMyReview(reviewId: String!, review: EditReviewInput!): Review!
   setInteraction(
     reviewId: String!
     interaction: ReviewInteractionType!

--- a/src/review/review.resolver.ts
+++ b/src/review/review.resolver.ts
@@ -8,9 +8,9 @@ import {
   CreateReviewInput,
   EditReviewInput,
   Review,
+  ReviewInteractionType,
   ReviewStatus,
 } from 'src/graphql'
-import { ReviewInteractionType } from 'src/schemas/review.schema'
 import { ReviewService } from './review.service'
 
 @Resolver('Review')

--- a/src/review/review.resolver.ts
+++ b/src/review/review.resolver.ts
@@ -46,13 +46,13 @@ export class ReviewResolver {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Mutation('setInteraction')
+  @Mutation('setReviewInteraction')
   async like(
     @Args('reviewId') reviewId: string,
-    @Args('interaction') interaction: ReviewInteractionType,
+    @Args('interactionType') interactionType: ReviewInteractionType,
     @CurrentUser() userId: string
   ): Promise<Review> {
-    return this.reviewService.setInteraction(reviewId, interaction, userId)
+    return this.reviewService.setInteraction(reviewId, interactionType, userId)
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/review/review.resolver.ts
+++ b/src/review/review.resolver.ts
@@ -66,13 +66,13 @@ export class ReviewResolver {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Mutation('editMyPendingReview')
+  @Mutation('editMyReview')
   async editMyPendingReview(
     @Args('reviewId') reviewId: string,
     @Args('review') review: EditReviewInput,
     @CurrentUser() userId: string
   ): Promise<Review> {
-    return this.reviewService.editMyPendingReview(reviewId, review, userId)
+    return this.reviewService.editMyReview(reviewId, review, userId)
   }
 
   @UseGuards(AdminAuthGuard)

--- a/src/review/review.resolver.ts
+++ b/src/review/review.resolver.ts
@@ -4,7 +4,12 @@ import { StudyProgram } from '@thinc-org/chula-courses'
 import { AdminAuthGuard } from 'src/auth/admin.guard'
 import { JwtAuthGuard, JwtAuthGuardOptional } from 'src/auth/jwt.guard'
 import { CurrentUser } from 'src/common/decorators/currentUser.decorator'
-import { CreateReviewInput, EditReviewInput, Review, Status } from 'src/graphql'
+import {
+  CreateReviewInput,
+  EditReviewInput,
+  Review,
+  ReviewStatus,
+} from 'src/graphql'
 import { ReviewInteractionType } from 'src/schemas/review.schema'
 import { ReviewService } from './review.service'
 
@@ -80,7 +85,7 @@ export class ReviewResolver {
   @Mutation('setReviewStatus')
   async setStatus(
     @Args('reviewId') reviewId: string,
-    @Args('status') status: Status
+    @Args('status') status: ReviewStatus
   ): Promise<string> {
     return this.reviewService.setStatus(reviewId, status)
   }

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -163,7 +163,7 @@ export class ReviewService {
     if (!review) {
       throw new NotFoundException({
         reason: 'REVIEW_NOT_FOUND',
-        message: `Error approving review ${reviewId}: Review not found`,
+        message: `Error setting status for review ${reviewId}: Review not found`,
       })
     }
     return 'Review status updated successfully'

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -117,10 +117,10 @@ export class ReviewService {
     userId: string
   ): Promise<Review> {
     const review = await this.reviewModel.findById(reviewId)
-    if (review.status !== 'PENDING') {
+    if (review.status === ReviewStatus.APPROVED) {
       throw new BadRequestException({
         reason: 'INVALID_STATUS',
-        message: 'Only PENDING status is supported',
+        message: 'Only APPROVED status is not supported',
       })
     }
     if (!review.ownerId.equals(userId)) {
@@ -132,7 +132,10 @@ export class ReviewService {
     const newReview = await this.reviewModel.findByIdAndUpdate(
       reviewId,
       {
-        $set: reviewInput,
+        $set: {
+          ...reviewInput,
+          status: ReviewStatus.PENDING,
+        },
       },
       { new: true }
     )

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -239,6 +239,7 @@ export class ReviewService {
       likeCount: likeCount,
       dislikeCount: dislikeCount,
       myInteraction: interactionType,
+      status: rawReview.status,
     }
   }
 }

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -94,19 +94,12 @@ export class ReviewService {
   ): Promise<Review[]> {
     const reviews = await this.reviewModel.find({
       $or: [
-        {
-          ownerId: userId,
-          courseNo,
-          studyProgram,
-          status: ReviewStatus.PENDING,
-        },
-        {
-          ownerId: userId,
-          courseNo,
-          studyProgram,
-          status: ReviewStatus.REJECTED,
-        },
+        { status: ReviewStatus.PENDING },
+        { status: ReviewStatus.REJECTED },
       ],
+      ownerId: userId,
+      courseNo,
+      studyProgram,
     })
     return reviews.map((rawReview) => this.transformReview(rawReview, null))
   }

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -149,25 +149,23 @@ export class ReviewService {
 
   // TODO: hide reviews?
   async setStatus(reviewId: string, status: ReviewStatus): Promise<string> {
-    if (status in ReviewStatus) {
-      const review = await this.reviewModel.findByIdAndUpdate(reviewId, {
-        $set: {
-          status,
-        },
-      })
-      if (!review) {
-        throw new NotFoundException({
-          reason: 'REVIEW_NOT_FOUND',
-          message: `Error approving review ${reviewId}: Review not found`,
-        })
-      }
-    } else {
+    if (status !== ReviewStatus.APPROVED && status !== ReviewStatus.REJECTED) {
       throw new BadRequestException({
         reason: 'INVALID_STATUS',
-        message: 'APPROVED reviews can not be edited!',
+        message: 'Only APPROVED and REJECTED status is supported',
       })
     }
-
+    const review = await this.reviewModel.findByIdAndUpdate(reviewId, {
+      $set: {
+        status,
+      },
+    })
+    if (!review) {
+      throw new NotFoundException({
+        reason: 'REVIEW_NOT_FOUND',
+        message: `Error approving review ${reviewId}: Review not found`,
+      })
+    }
     return 'Review status updated successfully'
   }
 

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -147,33 +147,24 @@ export class ReviewService {
     return this.transformReview(review, userId)
   }
 
-  async changeStatus(
-    reviewId: string,
-    status: ReviewStatus
-  ): Promise<ReviewDocument> {
-    const review = await this.reviewModel.findByIdAndUpdate(reviewId, {
-      $set: {
-        status,
-      },
-    })
-    if (!review) {
-      throw new NotFoundException({
-        reason: 'REVIEW_NOT_FOUND',
-        message: `Error approving review ${reviewId}: Review not found`,
-      })
-    }
-    return review
-  }
-
   // TODO: hide reviews?
-
   async setStatus(reviewId: string, status: ReviewStatus): Promise<string> {
     if (status in ReviewStatus) {
-      await this.changeStatus(reviewId, status)
+      const review = await this.reviewModel.findByIdAndUpdate(reviewId, {
+        $set: {
+          status,
+        },
+      })
+      if (!review) {
+        throw new NotFoundException({
+          reason: 'REVIEW_NOT_FOUND',
+          message: `Error approving review ${reviewId}: Review not found`,
+        })
+      }
     } else {
       throw new BadRequestException({
         reason: 'INVALID_STATUS',
-        message: 'Only APPROVED and REJECTED status is supported',
+        message: 'APPROVED reviews can not be edited!',
       })
     }
 

--- a/src/schemas/review.schema.ts
+++ b/src/schemas/review.schema.ts
@@ -1,9 +1,14 @@
 import { StudyProgram } from '@thinc-org/chula-courses'
 import * as mongoose from 'mongoose'
+import { ReviewInteractionType, ReviewStatus } from 'src/graphql'
 
 export const InteractionSchema = new mongoose.Schema({
   userId: { type: mongoose.Schema.Types.ObjectId, required: true, ref: 'user' },
-  type: { type: String, required: true, enum: ['L', 'D'] },
+  type: {
+    type: String,
+    required: true,
+    enum: Object.values(ReviewInteractionType),
+  },
 })
 
 export const ReviewSchema = new mongoose.Schema({
@@ -19,11 +24,8 @@ export const ReviewSchema = new mongoose.Schema({
   rating: { type: Number, required: true },
   content: { type: String },
   interactions: [InteractionSchema],
-  status: { type: String, default: 'PENDING' },
+  status: { type: String, default: ReviewStatus.PENDING },
 })
-
-export type ReviewInteractionType = 'L' | 'D'
-export type ReviewStatus = 'PENDING' | 'APPROVED' | 'HIDDEN'
 
 export interface ReviewInteraction {
   userId: mongoose.Types.ObjectId


### PR DESCRIPTION
## What I do
- เปลี่ยนชื่อจาก `Status` -> `ReviewStatus` เพราะ `Status` เฉยๆ มัน general เกินไป
- เปลี่ยนชื่อจาก `Interaction` -> `ReviewInteractionType` เนื่องด้วยเหตุผลเดียวกัน
- เวลา reject review จะไป Update review status ให้เป็น REJECTED แทนที่จะลบทิ้ง 
- เวลาแก้ไข Review จะ set status ให้เป็น PENDING เสมอ (เพราะเราสามารถแก้ไข Rejected Review ได้)
- เวลาเรียก MyPendingReview จะเอาทั้ง review ที่ติดสถานะ PENDING, REJECTED มาด้วย
- พยายามใช้ enum แทนจุดที่ใช้ string ตรงๆ (ทำไม่ครบ แต่ทำแค่ในส่วนที่เกี่ยวข้อง)
- เพิ่ท field `status` ใน Review Graphql ด้วย เพราะต้องใช้แสดงผลใน frontend ว่าอันไหน pending อันไหน rejected

## Demo 
https://dev.cugetreg.com/S/courses/0201122